### PR TITLE
Fix printing of stdout/err, drop (vestigial?) nrepl-eval fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ You can get cljs-noderepl running on an nREPL server through
 [Piggieback](https://github.com/cemerick/piggieback), though it's a
 bit fiddly. Here's how.
 
-You need to add Piggieback and cljs-noderepl as project dependencies
-(you'll probably want to keep this in the `:dev` profile or something
-similar) in your `project.clj` file:
+Add the cljs-noderepl dependency to your `project.clj` (it will bring in
+Piggieback transitively):
 
 ```clojure
-:dependencies [...
-               [org.bodil/cljs-noderepl "0.1.6"]
-               [com.cemerick/piggieback "0.0.2"]]
+[org.bodil/cljs-noderepl "0.1.6"]
 ```
+
+(You may want to add this dependency to your `:dev` profile so it's not carried
+along when you deploy your library/application.)
 
 Then, add the Piggieback nREPL middleware, also in `project.clj`:
 

--- a/cljs-noderepl/project.clj
+++ b/cljs-noderepl/project.clj
@@ -6,4 +6,4 @@
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.clojure/clojurescript "0.0-1576"]
                  [cheshire "5.0.1"]
-                 [com.cemerick/piggieback "0.0.2"]])
+                 [com.cemerick/piggieback "0.0.4"]])

--- a/cljs-noderepl/src/cljs/repl/node.clj
+++ b/cljs-noderepl/src/cljs/repl/node.clj
@@ -32,7 +32,7 @@
       (while (alive-func)
         (let [line (.readLine reader)
               data (parse-string line)]
-          (if-let [output (:output data)]
+          (if-let [output (get data "output")]
             (print output)
             (doto pipe
               (.write (str line "\n"))

--- a/cljs-noderepl/src/cljs/repl/node.clj
+++ b/cljs-noderepl/src/cljs/repl/node.clj
@@ -132,35 +132,5 @@
 (defn nrepl-env []
   (doto (repl-env) (node-setup)))
 
-(defn- nrepl-quit [env]
-  (node-tear-down env)
-  (set! ana/*cljs-ns* 'cljs.user))
-
-(defn nrepl-eval
-  [repl-env expr {:keys [verbose warn-on-undeclared special-fns]}]
-  (binding [repl/*cljs-verbose* verbose
-            ana/*cljs-warn-on-undeclared* warn-on-undeclared]
-    (let [special-fns (merge repl/default-special-fns special-fns)
-          is-special-fn? (set (keys special-fns))]
-      (cond
-       (= expr :cljs/quit) (do (nrepl-quit repl-env) :cljs/quit)
-
-       (and (seq? expr) (is-special-fn? (first expr)))
-       (apply (get special-fns (first expr)) repl-env (rest expr))
-
-       :default
-       (let [ret (repl/evaluate-form
-                  repl-env
-                  {:context :statement :locals {}
-                   :ns (ana/get-namespace ana/*cljs-ns*)}
-                  "<cljs repl>"
-                  expr
-                  (#'repl/wrap-fn expr))]
-         (try
-           (read-string ret)
-           (catch Exception _
-             (when (string? ret)
-               (println ret)))))))))
-
 (defn run-node-nrepl []
-  (piggieback/cljs-repl :repl-env (nrepl-env) :eval nrepl-eval))
+  (piggieback/cljs-repl :repl-env (nrepl-env)))


### PR DESCRIPTION
AFAICT, the `nrepl-eval` fn is not necessary.  Perhaps there was an issue with piggieback ~0.0.2 that prompted it?

Anyway, bumped piggieback to 0.0.4, eliminated `nrepl-eval`, and all's well.

Thanks for the sane REPL environment! :-)
