### PR TITLE
Update to Piggieback 0.1.2 and add support for cljs.repl compiler environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To setup the Leiningen plugin, add this to your `project.clj` or
 `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[org.bodil/lein-noderepl "0.1.11"]]
+:plugins [[org.bodil/lein-noderepl "0.1.10"]]
 ```
 
 Then, start the REPL like this:
@@ -26,7 +26,7 @@ $ lein trampoline noderepl
 Add the following dependency to your `project.clj`:
 
 ```clojure
-[org.bodil/cljs-noderepl "0.1.11"]
+[org.bodil/cljs-noderepl "0.1.10"]
 ```
 
 To launch the REPL the hard way, run `lein repl` and enter the following:
@@ -69,7 +69,7 @@ Add the cljs-noderepl dependency to your `project.clj` (it will bring
 in Piggieback transitively):
 
 ```clojure
-[org.bodil/cljs-noderepl "0.1.11"]
+[org.bodil/cljs-noderepl "0.1.10"]
 ```
 
 You may want to add this dependency to your `:dev` profile so it's not

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To setup the Leiningen plugin, add this to your `project.clj` or
 `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[org.bodil/lein-noderepl "0.1.10"]]
+:plugins [[org.bodil/lein-noderepl "0.1.11"]]
 ```
 
 Then, start the REPL like this:
@@ -26,7 +26,7 @@ $ lein trampoline noderepl
 Add the following dependency to your `project.clj`:
 
 ```clojure
-[org.bodil/cljs-noderepl "0.1.10"]
+[org.bodil/cljs-noderepl "0.1.11"]
 ```
 
 To launch the REPL the hard way, run `lein repl` and enter the following:
@@ -69,7 +69,7 @@ Add the cljs-noderepl dependency to your `project.clj` (it will bring
 in Piggieback transitively):
 
 ```clojure
-[org.bodil/cljs-noderepl "0.1.10"]
+[org.bodil/cljs-noderepl "0.1.11"]
 ```
 
 You may want to add this dependency to your `:dev` profile so it's not

--- a/cljs-noderepl/project.clj
+++ b/cljs-noderepl/project.clj
@@ -5,5 +5,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [cheshire "5.2.0"]
-                 [com.cemerick/piggieback "0.0.5"]]
+                 [com.cemerick/piggieback "0.1.2"]]
   :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]})

--- a/cljs-noderepl/project.clj
+++ b/cljs-noderepl/project.clj
@@ -1,4 +1,4 @@
-(defproject org.bodil/cljs-noderepl "0.1.10"
+(defproject org.bodil/cljs-noderepl "0.1.11"
   :description "Node.js REPL environment for Clojurescript"
   :url "https://github.com/bodil/cljs-noderepl"
   :license {:name "Eclipse Public License"

--- a/cljs-noderepl/project.clj
+++ b/cljs-noderepl/project.clj
@@ -1,4 +1,4 @@
-(defproject org.bodil/cljs-noderepl "0.1.11"
+(defproject org.bodil/cljs-noderepl "0.1.11-SNAPSHOT"
   :description "Node.js REPL environment for Clojurescript"
   :url "https://github.com/bodil/cljs-noderepl"
   :license {:name "Eclipse Public License"

--- a/cljs-noderepl/src/cljs/repl/node.clj
+++ b/cljs-noderepl/src/cljs/repl/node.clj
@@ -135,9 +135,6 @@
 
 (defn run-node-repl []
   (repl/repl (repl-env)))
-
-(defn nrepl-env []
-  (doto (repl-env) (node-setup)))
-
+                                        
 (defn run-node-nrepl []
-  (piggieback/cljs-repl :repl-env (nrepl-env)))
+  (piggieback/cljs-repl :repl-env (repl-env)))

--- a/lein-noderepl/project.clj
+++ b/lein-noderepl/project.clj
@@ -1,4 +1,4 @@
-(defproject org.bodil/lein-noderepl "0.1.10"
+(defproject org.bodil/lein-noderepl "0.1.11"
   :description "Leiningen plugin for launching a Node.js CLJS REPL"
   :url "https://github.com/bodil/cljs-noderepl"
   :license {:name "Eclipse Public License"

--- a/lein-noderepl/project.clj
+++ b/lein-noderepl/project.clj
@@ -1,4 +1,4 @@
-(defproject org.bodil/lein-noderepl "0.1.11"
+(defproject org.bodil/lein-noderepl "0.1.11-SNAPSHOT"
   :description "Leiningen plugin for launching a Node.js CLJS REPL"
   :url "https://github.com/bodil/cljs-noderepl"
   :license {:name "Eclipse Public License"

--- a/lein-noderepl/src/leiningen/noderepl.clj
+++ b/lein-noderepl/src/leiningen/noderepl.clj
@@ -15,7 +15,7 @@
   "Launch a ClojureScript REPL on Node.js."
   [project & args]
   (require-trampoline
-   (let [project (deps/add-if-missing project '[org.bodil/cljs-noderepl "0.1.10"])]
+   (let [project (deps/add-if-missing project '[org.bodil/cljs-noderepl "0.1.11"])]
      (in-project project []
                  (ns (:require [cljs.repl.node :as node]))
                  (node/run-node-repl)))))

--- a/lein-noderepl/src/leiningen/noderepl.clj
+++ b/lein-noderepl/src/leiningen/noderepl.clj
@@ -15,7 +15,7 @@
   "Launch a ClojureScript REPL on Node.js."
   [project & args]
   (require-trampoline
-   (let [project (deps/add-if-missing project '[org.bodil/cljs-noderepl "0.1.11"])]
+   (let [project (deps/add-if-missing project '[org.bodil/cljs-noderepl "0.1.11-SNAPSHOT"])]
      (in-project project []
                  (ns (:require [cljs.repl.node :as node]))
                  (node/run-node-repl)))))

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.bodil/cljs-noderepl-root "0.1.11"
+(defproject org.bodil/cljs-noderepl-root "0.1.11-SNAPSHOT"
   :description "Node.js REPL environment for Clojurescript"
   :url "https://github.com/bodil/cljs-noderepl"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.bodil/cljs-noderepl-root "0.1.10"
+(defproject org.bodil/cljs-noderepl-root "0.1.11"
   :description "Node.js REPL environment for Clojurescript"
   :url "https://github.com/bodil/cljs-noderepl"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
I was getting NullPointerExceptions while trying to use cljs-noderepl with the latest ClojureScript. This would also happen with Piggieback/nREPL.

After updating to the latest Piggieback, I realised that the call to `node-setup` in `nrepl-env` was causing problems. It would give a NullPointerException while internally deref'ing the compiler var.

I've now wrapped the node-setup function to use the repl-env compiler environment or the default one. I also added the default compiler environment to the node repl-env.

With these changes, the REPL can now be launched using the 3 prescribed methods in the README, using the latest ClojureScript, Piggieback and Node.
